### PR TITLE
feat: replace systemd deployment with Docker and ghcr.io

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
         branches:
             - main
 
+permissions:
+    contents: read
+    packages: write
+
 jobs:
     deploy:
         runs-on: ubuntu-latest
@@ -37,4 +41,5 @@ jobs:
                       docker pull ghcr.io/${{ github.repository }}:latest
                       docker stop go-scheduler || true
                       docker rm go-scheduler || true
-                      docker run -d --restart=on-failure --name go-scheduler --env-file /etc/go-scheduler.env ghcr.io/${{ github.repository }}:latest
+                      docker run -d --restart=unless-stopped --name go-scheduler --env-file /etc/go-scheduler.env ghcr.io/${{ github.repository }}:latest
+                      docker image prune -f --filter "dangling=true"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,29 +13,28 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
-            - name: Set up Go
-              uses: actions/setup-go@v5
+            - name: Log in to GitHub Container Registry
+              uses: docker/login-action@v3
               with:
-                  go-version: "1.25"
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Build go-scheduler Binary
-              run: GOOS=linux GOARCH=amd64 go build -o go-scheduler ./cmd/scheduler
-
-            - name: Copy binary to VPS
-              uses: appleboy/scp-action@v0.1.7
+            - name: Build and push Docker image
+              uses: docker/build-push-action@v6
               with:
-                  host: ${{ secrets.VPS_HOST }}
-                  username: ${{ secrets.VPS_USER }}
-                  key: ${{ secrets.VPS_SSH_KEY }}
-                  source: "go-scheduler"
-                  target: /root/
-            - name: Deploy and restart service
+                  context: .
+                  push: true
+                  tags: ghcr.io/${{ github.repository }}:latest
+
+            - name: Pull and run Docker container on VPS
               uses: appleboy/ssh-action@v0.1.3
               with:
                   host: ${{ secrets.VPS_HOST }}
                   username: ${{ secrets.VPS_USER }}
                   key: ${{ secrets.VPS_SSH_KEY }}
                   script: |
-                      systemctl stop go-scheduler
-                      systemctl daemon-reload
-                      systemctl start go-scheduler
+                      docker pull ghcr.io/${{ github.repository }}:latest
+                      docker stop go-scheduler || true
+                      docker rm go-scheduler || true
+                      docker run -d --restart=on-failure --name go-scheduler --env-file /etc/go-scheduler.env ghcr.io/${{ github.repository }}:latest

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -76,7 +76,7 @@ Paste the following, filling in real values:
 
     docker run -d \
       --name go-scheduler \
-      --restart=on-failure \
+      --restart=unless-stopped \
       --env-file /etc/go-scheduler.env \
       ghcr.io/sriram651/go-scheduler:latest
 
@@ -111,7 +111,7 @@ To change a secret or config value:
 
         docker stop go-scheduler
         docker rm go-scheduler
-        docker run -d --name go-scheduler --restart=on-failure --env-file /etc/go-scheduler.env ghcr.io/sriram651/go-scheduler:latest
+        docker run -d --name go-scheduler --restart=unless-stopped --env-file /etc/go-scheduler.env ghcr.io/sriram651/go-scheduler:latest
 
 ------------------------------------------------------------------------
 
@@ -127,10 +127,10 @@ To change a secret or config value:
 
 ## Summary
 
-| Action             | Command                                                                        |
-| ------------------ | ------------------------------------------------------------------------------ |
-| Deploy             | Push to `main` — Actions handles the rest                                      |
-| Check status       | `docker ps`                                                                    |
-| Tail logs          | `docker logs -f go-scheduler`                                                  |
-| Restart container  | `docker restart go-scheduler`                                                  |
-| Update env vars    | Edit `/etc/go-scheduler.env`, then stop/rm/run the container                  |
+| Action            | Command                                                      |
+| ----------------- | ------------------------------------------------------------ |
+| Deploy            | Push to `main` — Actions handles the rest                    |
+| Check status      | `docker ps`                                                  |
+| Tail logs         | `docker logs -f go-scheduler`                                |
+| Restart container | `docker restart go-scheduler`                                |
+| Update env vars   | Edit `/etc/go-scheduler.env`, then stop/rm/run the container |

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,65 +1,38 @@
 # Deployment Guide
 
-How to build and push a new binary to the Hostinger VPS, with secrets
-managed entirely on the server via a systemd service file.
+The service runs as a Docker container on a Hostinger VPS. Deployments
+are fully automated via GitHub Actions — every push to `main` builds a
+new image, pushes it to GitHub Container Registry, and restarts the
+container on the VPS.
 
 No secrets are committed to this repository.
+
+------------------------------------------------------------------------
+
+## How Deployments Work
+
+1. Push to `main` triggers the GitHub Actions workflow
+2. Actions builds the Docker image and pushes it to `ghcr.io/sriram651/go-scheduler:latest`
+3. Actions SSHes into the VPS and runs:
+   - `docker pull` — fetches the new image
+   - `docker stop` + `docker rm` — removes the old container
+   - `docker run` — starts a fresh container from the new image
 
 ------------------------------------------------------------------------
 
 ## Prerequisites
 
 - SSH access to the VPS
-- Go installed locally (for building)
-- The systemd service already set up on the server (see First-Time Setup)
+- Docker installed on the VPS
+- GitHub Actions secrets configured: `VPS_HOST`, `VPS_USER`, `VPS_SSH_KEY`
 
 ------------------------------------------------------------------------
 
-## Building the Binary
+## First-Time VPS Setup
 
-Cross-compile for Linux (the VPS target) from your local machine:
+### 1. Install Docker
 
-    GOOS=linux GOARCH=amd64 go build -o go-scheduler ./cmd/scheduler/
-
-This produces a `go-scheduler` binary in the project root.
-
-> If your VPS uses a different architecture (e.g. ARM), set
-> `GOARCH=arm64` instead.
-
-------------------------------------------------------------------------
-
-## Pushing a New Build
-
-Copy the binary to the VPS:
-
-    scp go-scheduler user@your-vps-ip:/path/to/app/go-scheduler
-
-Then restart the service to pick up the new binary:
-
-    ssh user@your-vps-ip "sudo systemctl restart go-scheduler"
-
-Verify it came back up cleanly:
-
-    ssh user@your-vps-ip "sudo systemctl status go-scheduler"
-
-------------------------------------------------------------------------
-
-## Checking Logs
-
-    ssh user@your-vps-ip "sudo journalctl -u go-scheduler -f"
-
-Or to see the last 50 lines without following:
-
-    ssh user@your-vps-ip "sudo journalctl -u go-scheduler -n 50 --no-pager"
-
-------------------------------------------------------------------------
-
-## First-Time Setup on the VPS
-
-### 1. Copy the binary
-
-    scp go-scheduler user@your-vps-ip:/path/to/app/go-scheduler
-    ssh user@your-vps-ip "chmod +x /path/to/app/go-scheduler"
+    curl -fsSL https://get.docker.com | sh
 
 ### 2. Set up the database schema
 
@@ -83,47 +56,46 @@ INSERT INTO bot_config (key, value) VALUES ('telegram_offset', '0');
 
 > **The `INSERT` above is required.** If the `telegram_offset` row is missing, the service will log a warning at startup and continue running, but offset persistence will be silently broken — messages may replay on every restart.
 
-### 3. Create the systemd service file
+### 3. Create the env file
 
-On the VPS, create `/etc/systemd/system/go-scheduler.service`:
+Create `/etc/go-scheduler.env` on the VPS:
 
-    sudo nano /etc/systemd/system/go-scheduler.service
+    sudo nano /etc/go-scheduler.env
 
-Paste the following, filling in real values under `[Service]`:
+Paste the following, filling in real values:
 
-```ini
-[Unit]
-Description=Go Cron Telegram Reminder Service
-After=network.target
+    TG_BOT_TOKEN=your_tg_bot_token_here
+    TG_API_BASE_URL=https://api.telegram.org/bot
+    QUOTE_API_URL=https://your-quote-api.com/api/random
+    DEFAULT_QUOTE=Your fallback quote here.
+    DATABASE_URL=postgres://user:password@host:5432/dbname
 
-[Service]
-Type=simple
-ExecStart=/path/to/app/go-scheduler --schedule "0 * * * *"
-Restart=on-failure
-RestartSec=10
+> This file lives only on the server and is never committed to git.
 
-Environment="TG_BOT_TOKEN=your_tg_bot_token_here"
-Environment="TG_API_BASE_URL=https://api.telegram.org/bot"
-Environment="QUOTE_API_URL=https://your-quote-api.com/api/random"
-Environment="DEFAULT_QUOTE=Your fallback quote here."
-Environment="DATABASE_URL=postgres://user:password@host:5432/dbname"
+### 4. Run the container manually (first time)
 
-[Install]
-WantedBy=multi-user.target
-```
+    docker run -d \
+      --name go-scheduler \
+      --restart=on-failure \
+      --env-file /etc/go-scheduler.env \
+      ghcr.io/sriram651/go-scheduler:latest
 
-> The `Environment=` lines live only on the server and are never
-> committed to git. This is the only place secrets should exist.
+### 5. Verify it is running
 
-### 4. Enable and start the service
+    docker ps
+    docker logs go-scheduler
 
-    sudo systemctl daemon-reload
-    sudo systemctl enable go-scheduler
-    sudo systemctl start go-scheduler
+------------------------------------------------------------------------
 
-### 5. Confirm it is running
+## Checking Logs
 
-    sudo systemctl status go-scheduler
+Follow live logs:
+
+    docker logs -f go-scheduler
+
+Last 50 lines:
+
+    docker logs --tail 50 go-scheduler
 
 ------------------------------------------------------------------------
 
@@ -131,26 +103,34 @@ WantedBy=multi-user.target
 
 To change a secret or config value:
 
-1. Edit the service file on the VPS:
+1. Edit the env file on the VPS:
 
-        sudo nano /etc/systemd/system/go-scheduler.service
+        sudo nano /etc/go-scheduler.env
 
-2. Update the relevant `Environment=` line.
+2. Restart the container to pick up the new values:
 
-3. Reload and restart:
+        docker stop go-scheduler
+        docker rm go-scheduler
+        docker run -d --name go-scheduler --restart=on-failure --env-file /etc/go-scheduler.env ghcr.io/sriram651/go-scheduler:latest
 
-        sudo systemctl daemon-reload
-        sudo systemctl restart go-scheduler
+------------------------------------------------------------------------
+
+## GitHub Actions Secrets Required
+
+| Secret        | Description                        |
+| ------------- | ---------------------------------- |
+| `VPS_HOST`    | IP address of the VPS              |
+| `VPS_USER`    | SSH username (e.g. `root`)         |
+| `VPS_SSH_KEY` | Ed25519 private key for SSH access |
 
 ------------------------------------------------------------------------
 
 ## Summary
 
-| Action          | Command                                                             |
-| --------------- | ------------------------------------------------------------------- |
-| Build for Linux | `GOOS=linux GOARCH=amd64 go build -o go-scheduler ./cmd/scheduler/` |
-| Push binary     | `scp go-scheduler user@vps-ip:/path/to/app/`                        |
-| Restart service | `sudo systemctl restart go-scheduler`                               |
-| Check status    | `sudo systemctl status go-scheduler`                                |
-| Tail logs       | `sudo journalctl -u go-scheduler -f`                                |
-| Edit env vars   | `sudo nano /etc/systemd/system/go-scheduler.service`                |
+| Action             | Command                                                                        |
+| ------------------ | ------------------------------------------------------------------------------ |
+| Deploy             | Push to `main` — Actions handles the rest                                      |
+| Check status       | `docker ps`                                                                    |
+| Tail logs          | `docker logs -f go-scheduler`                                                  |
+| Restart container  | `docker restart go-scheduler`                                                  |
+| Update env vars    | Edit `/etc/go-scheduler.env`, then stop/rm/run the container                  |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.25 AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o scheduler ./cmd/scheduler
+
+FROM alpine:3.21
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+WORKDIR /app
+
+COPY --from=builder /app/scheduler .
+
+USER appuser
+
+ENTRYPOINT [ "./scheduler" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
 WORKDIR /app
 
+RUN apk --no-cache add ca-certificates
+
 COPY --from=builder /app/scheduler .
 
 USER appuser

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ It is designed to run as a long-lived background service.
     │       ├── handlers.go      # Message and callback query handlers
     │       ├── polling.go       # Long-polling implementation
     │       └── types.go         # Telegram API type definitions
+    ├── Dockerfile               # Two-stage build: golang builder → alpine runtime
     ├── .env                     # Local secrets — never committed
     ├── .env.example             # Safe template to commit
     ├── DEPLOY.md                # VPS deployment guide
@@ -277,9 +278,14 @@ Encapsulates:
 
 ## Deployment
 
-The compiled binary is deployed and running on a Hostinger VPS as a
-long-lived background service. Environment variables are configured
-directly in the service file on the host.
+The service runs as a Docker container on a Hostinger VPS. The image is
+built and pushed to GitHub Container Registry (`ghcr.io`) via GitHub
+Actions on every push to `main`. The VPS pulls the latest image and
+restarts the container automatically.
+
+Environment variables are stored in an env file on the VPS and injected
+at container startup via `--env-file`. No secrets are committed to this
+repository.
 
 See [DEPLOY.md](DEPLOY.md) for the full deployment guide.
 
@@ -302,5 +308,4 @@ See [DEPLOY.md](DEPLOY.md) for the full deployment guide.
 
 -   Retry logic for transient failures
 -   Multi-reminder support
--   Dockerization
 -   Observability improvements


### PR DESCRIPTION
# feat: Dockerize deployment

Replaces _raw binary + systemd_ deployment with a _Docker container_.

## Changes

- **Dockerfile** — two-stage build: `golang:1.25` compiles the binary, `alpine:3.21` runs it. Runs as a non-root user.
- **GitHub Actions** — updated workflow builds the image, pushes to `ghcr.io`, and deploys to VPS via SSH. Removed `scp` binary step and systemd restart.
- **Docs** — README and DEPLOY.md updated to reflect the new Docker-based deployment flow.

## Deploy flow

Push to `main` → Actions builds and pushes image to `ghcr.io` → VPS pulls image and restarts container.