### PR TITLE
feat: timezone-aware quote scheduling

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -41,7 +41,8 @@ CREATE TABLE users (
     chat_id    BIGINT  PRIMARY KEY,
     first_name TEXT    NOT NULL,
     username   TEXT,
-    subscribed BOOLEAN NOT NULL DEFAULT false
+    subscribed BOOLEAN NOT NULL DEFAULT false,
+    timezone   TEXT
 );
 
 CREATE TABLE bot_config (
@@ -50,9 +51,14 @@ CREATE TABLE bot_config (
 );
 
 INSERT INTO bot_config (key, value) VALUES ('telegram_offset', '0');
+INSERT INTO bot_config (key, value) VALUES ('send_hour', '9');
 ```
 
-The `bot_config` insert is required — without it, the Telegram offset won't persist and messages will replay on restart.
+Both `bot_config` inserts are required:
+- Without `telegram_offset`, the offset won't persist and messages will replay on restart.
+- Without `send_hour`, the bot falls back to hour `0` (midnight UTC) and delivers quotes at inconvenient local times for everyone.
+
+`users.timezone` is nullable — users who haven't run `/timezone` fall back to UTC.
 
 ## Architecture
 
@@ -98,23 +104,22 @@ This project is a learning-oriented codebase. The owner values understanding ove
 - **Context cancel: call directly, don't defer** — cancel the context directly after the operation it guards so resources are released promptly, not at function return.
 - **Telegram `answerCallbackQuery` must be called before any other response** — stale callback IDs from restarts are harmless noise; just answer and move on.
 - **`bot_config` seed row is required** — `UPDATE` with no matching `telegram_offset` row affects 0 rows silently. Symptom: messages replay on every restart.
+- **Retry + timeout contexts** — a timeout context created outside a retry loop gets cancelled before later attempts run. Create the per-attempt timeout inside the retry function, not around it.
 
 ## Decisions Already Made — Don't Revisit
 
 - **No concurrent broadcast sends yet** — sequential is fine for the current user count, but concurrency must come before retry logic. Retrying inside a sequential loop blocks all subsequent users.
-- **No retry logic yet** — blocked on concurrent broadcast sends. A plan is drafted in `docs/plan/retry-plan.md`.
+- **No retry logic yet** — blocked on concurrent broadcast sends.
 - **Dev environment is local** — `go run ./cmd/scheduler/` with a dev bot token and a dev Neon DB branch. No dev container on the VPS.
 - **Docker is prod-only** — single container on Fly.io, secrets managed via `flyctl secrets set`. No multi-environment Docker setup.
 - **`bot_config` is a generic key-value table** — kept flexible for future runtime state without over-engineering.
 - **Single category selection only** — the new quote API uses AND logic across categories, making multi-select unreliable. Verified against the API. Not a design choice — a hard constraint.
-- **No per-user schedule preference** — fixed 1/day hardcoded cron for everyone. Keeps the scheduler model simple.
+- **No per-user send-hour preference** — global `send_hour` in `bot_config`, per-user timezone on `users.timezone`. Every user receives their quote at `send_hour` in their local timezone (UTC fallback when timezone is null). Users cannot customize the hour itself.
 
-## Planned Work
+## Possible Future Work
 
-See `docs/plan/custom-config-plan.md` for the full design. Work is divided into three phases:
+Short pointers — not committed. Each needs its own plan when actually picked up.
 
-- **Phase 1 — Cache + Deduplication:** Store fetched quotes and stop sending the same quote to the same user twice. Uses existing API with its stable ID as cache key. Start here.
-- **Phase 2 — Hashing:** Replace the API's ID with a SHA-256 content hash as the cache key. Validates hashing logic in isolation before the API swap.
-- **Phase 3 — New Endpoint + Category Preference:** Swap quote API, add per-user category selection via `/settings`, update broadcast to group users by category and fetch per unique category.
-
-Retry logic is deferred until after concurrent broadcast sends are implemented. See `docs/plan/retry-plan.md`.
+- **Quote dedup** — avoid sending the same quote to the same user twice. The current quote API returns no stable ID, so any dedup scheme must hash content (e.g. SHA-256 of text + author) as the cache key. Per-user, not global.
+- **Per-user category preference** — single-select only (API uses AND across categories; see "Decisions Already Made").
+- **Concurrent broadcast sends** — prerequisite for retry logic.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,7 +16,7 @@ go build -o go-scheduler ./cmd/scheduler/
 ./go-scheduler --schedule "@every 30s"
 ```
 
-**Run (default schedule — every 6 hours):**
+**Run (default schedule — every hour):**
 ```sh
 ./go-scheduler
 ```

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -102,7 +102,7 @@ This project is a learning-oriented codebase. The owner values understanding ove
 ## Decisions Already Made — Don't Revisit
 
 - **No concurrent broadcast sends yet** — sequential is fine for the current user count, but concurrency must come before retry logic. Retrying inside a sequential loop blocks all subsequent users.
-- **No retry logic yet** — blocked on concurrent broadcast sends. A plan is drafted in `retry-plan.md`.
+- **No retry logic yet** — blocked on concurrent broadcast sends. A plan is drafted in `docs/plan/retry-plan.md`.
 - **Dev environment is local** — `go run ./cmd/scheduler/` with a dev bot token and a dev Neon DB branch. No dev container on the VPS.
 - **Docker is prod-only** — single container on Fly.io, secrets managed via `flyctl secrets set`. No multi-environment Docker setup.
 - **`bot_config` is a generic key-value table** — kept flexible for future runtime state without over-engineering.
@@ -111,10 +111,10 @@ This project is a learning-oriented codebase. The owner values understanding ove
 
 ## Planned Work
 
-See `custom-config-plan.md` for the full design. Work is divided into three phases:
+See `docs/plan/custom-config-plan.md` for the full design. Work is divided into three phases:
 
 - **Phase 1 — Cache + Deduplication:** Store fetched quotes and stop sending the same quote to the same user twice. Uses existing API with its stable ID as cache key. Start here.
 - **Phase 2 — Hashing:** Replace the API's ID with a SHA-256 content hash as the cache key. Validates hashing logic in isolation before the API swap.
 - **Phase 3 — New Endpoint + Category Preference:** Swap quote API, add per-user category selection via `/settings`, update broadcast to group users by category and fetch per unique category.
 
-Retry logic is deferred until after concurrent broadcast sends are implemented. See `retry-plan.md`.
+Retry logic is deferred until after concurrent broadcast sends are implemented. See `docs/plan/retry-plan.md`.

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Manages PostgreSQL connection and queries:
 -   `Connect(dbURL)` — opens and pings the connection
 -   `AddNewUser(db, user)` — upserts a user row; updates name fields without touching subscription state
 -   `UpdateSubscription(db, chatId, subscribed)` — sets subscribed flag for a user
--   `GetSubscribedUsers(db)` — returns chat IDs of all subscribed users
+-   `GetSubscribedUsersForHour(ctx, db, nowUTC, sendHour)` — returns chat IDs of subscribed users whose local hour (per their stored IANA timezone, UTC fallback) matches `sendHour`
 -   `GetTelegramOffset(db)` — reads the last saved update offset from `bot_config`
 -   `UpdateBotConfig(db, key, value)` — upserts a key-value row in `bot_config`
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This service:
 -   Falls back to a configurable default quote on fetch failure
 -   Sends messages using the Telegram Bot API
 -   Listens for Telegram updates via long-polling
--   Handles `/start`, `/subscribe`, `/unsubscribe`, and `/about` commands
+-   Handles `/start`, `/subscribe`, `/unsubscribe`, `/timezone`, and `/about` commands
 -   Routes callback queries (Subscribe / Unsubscribe)
 -   Registers new users in PostgreSQL on `/start` (upsert — safe to repeat)
 -   Persists subscription state in the database
@@ -127,7 +127,8 @@ Before running the service, run the following in your PostgreSQL database:
         chat_id    BIGINT  PRIMARY KEY,
         first_name TEXT    NOT NULL,
         username   TEXT,
-        subscribed BOOLEAN NOT NULL DEFAULT false
+        subscribed BOOLEAN NOT NULL DEFAULT false,
+        timezone   TEXT
     );
 
     CREATE TABLE bot_config (
@@ -136,11 +137,13 @@ Before running the service, run the following in your PostgreSQL database:
     );
 
     INSERT INTO bot_config (key, value) VALUES ('telegram_offset', '0');
+    INSERT INTO bot_config (key, value) VALUES ('send_hour', '9');
 
 - `chat_id` is the Telegram chat ID — used as the primary key and the conflict target for upserts.
 - `username` is nullable — not all Telegram users have a username set.
 - `subscribed` defaults to `false` on insert; updated via the Subscribe / Unsubscribe inline buttons.
-- `bot_config` stores runtime state that must survive restarts. The `telegram_offset` row tracks the last processed Telegram update ID to prevent message replay.
+- `timezone` is nullable — stores the user's IANA zone (e.g. `Asia/Kolkata`) set via `/timezone`. Users who haven't set one fall back to UTC.
+- `bot_config` stores runtime state that must survive restarts. The `telegram_offset` row tracks the last processed Telegram update ID to prevent message replay. The `send_hour` row holds the global hour (0–23) at which each user receives their quote in their local timezone.
 
 > **The `INSERT INTO bot_config` line is required.** If the `telegram_offset` row is missing, the service will log a warning at startup and continue running, but offset persistence will be silently broken — `UPDATE` with no matching row affects 0 rows. The symptom: Telegram messages may replay on every restart.
 
@@ -206,6 +209,7 @@ On Telegram message received:
 -   Routes to the appropriate handler
 -   `/start` registers the user and replies with a welcome message and inline keyboard
 -   `/subscribe` and `/unsubscribe` update subscription state directly — no need to go through `/start`
+-   `/timezone` opens a two-level inline keyboard (continent → zone) and persists the user's IANA timezone
 -   `/about` replies with a description of the bot and available commands
 -   Subscribe / Unsubscribe inline button callbacks also update subscription state
 -   Each processed update saves the new offset to DB
@@ -271,7 +275,7 @@ Encapsulates:
 -   Long-polling via `StartPolling(ctx)` — routes updates to handlers
 -   `HandleSend(ctx, chatId, text, replyMarkup)` — sends messages
 -   `handleMessage` / `handleCallback` — command and button routing
--   `/start` triggers user upsert; `/subscribe`, `/unsubscribe` update subscription directly; `/about` describes the bot
+-   `/start` triggers user upsert; `/subscribe`, `/unsubscribe` update subscription directly; `/timezone` sets the user's IANA timezone via a two-level picker; `/about` describes the bot
 -   Saves update offset to DB after each processed update
 
 ### Execution Model
@@ -302,7 +306,7 @@ See [DEPLOY.md](DEPLOY.md) for the full deployment guide.
 -   PostgreSQL-backed user registration and subscription management
 -   Broadcast targets fetched from the database at runtime
 -   Telegram update offset persisted — no stale replays on restart
--   Interactive Telegram commands via long-polling (`/start`, `/subscribe`, `/unsubscribe`, `/about`, callbacks)
+-   Interactive Telegram commands via long-polling (`/start`, `/subscribe`, `/unsubscribe`, `/timezone`, `/about`, callbacks)
 -   External quote API with fallback
 -   No retry policy
 -   No multi-job configuration

--- a/docs/plan/prd-timezone-scheduling.md
+++ b/docs/plan/prd-timezone-scheduling.md
@@ -1,0 +1,125 @@
+# PRD: Timezone-Aware Scheduling
+
+## Problem Statement
+
+Users in non-UTC timezones receive quotes at inconvenient local hours. The bot currently fires on a fixed UTC schedule (every 6 hours), meaning a user in Singapore receives quotes at 1AM, 7AM, 1PM, and 7PM local time with no control over timing. There is no way for a user to configure when they receive their daily quote relative to their local time.
+
+## Solution
+
+Allow each user to set their timezone once via a `/timezone` command. A single globally-configured send hour (e.g. 9AM) is stored in the bot config. The cron fires every hour, and on each fire, only users whose local time matches the configured send hour receive a quote. Users who have not set a timezone fall back to UTC.
+
+## User Stories
+
+1. As a subscribed user in a non-UTC timezone, I want to receive my quote at a reasonable local hour, so that it does not arrive at 1AM while I am asleep.
+2. As a subscribed user, I want to set my timezone through the Telegram bot, so that the bot knows when to send me quotes.
+3. As a subscribed user, I want to choose my timezone from a list of options presented as buttons, so that I do not have to type a timezone name manually.
+4. As a subscribed user, I want my timezone preference to be saved permanently, so that I do not have to set it again after every restart.
+5. As a subscribed user who has not set a timezone, I want to continue receiving quotes on the UTC schedule, so that the bot still works for me without any action required.
+6. As a subscribed user, I want to be able to change my timezone at any time, so that I can update it if I move or travel.
+7. As a subscribed user, I want confirmation after setting my timezone, so that I know the change was saved successfully.
+8. As the bot owner, I want to configure the global send hour once in the bot config, so that all users receive their quote at that hour in their respective local times.
+9. As the bot owner, I want the send hour to be loaded at startup, so that it does not require a DB read on every cron fire.
+10. As the bot owner, I want the cron to fire every hour instead of every 6 hours, so that users across all timezones are served at the correct local hour.
+11. As the bot owner, I want users who have not set a timezone to fall back to UTC automatically, so that existing users are unaffected by this change.
+12. As the bot owner, I want the list of supported timezones to be hardcoded in the application, so that no additional infrastructure is needed to manage them.
+13. As the bot owner, I want timezone names stored as IANA names (e.g. `Asia/Singapore`), so that daylight saving time is handled correctly at runtime without manual offset updates.
+14. As the bot owner, I want the user filtering logic to run in SQL, so that only relevant users are fetched per cron fire and no unnecessary data is transferred.
+15. As the bot owner, I want the current UTC time to be passed into the broadcast function from the scheduler, so that the filtering logic is testable in isolation.
+
+## Implementation Decisions
+
+### DB Schema Changes
+- Add a nullable `timezone TEXT` column to the `users` table. Null means UTC fallback — no migration needed for existing users.
+- Add a `send_hour` key to the `bot_config` table with the desired send hour as a string integer (e.g. `"9"` for 9AM). Loaded once at startup.
+
+### Config / `sendHour` placement
+- `send_hour` is loaded from `bot_config` at startup and lives on the consuming component.
+- **Amended during implementation:** originally specified as a new `Config.SendHour int` field. That conflicts with `Config`'s "loaded from env + flags at startup, read-only afterwards" invariant (the DB isn't up when `LoadConfig` runs). Resolved by placing `sendHour` on `Broadcast` as a private field, set via `Broadcast.UpdateSendHour(int)` from `app.Start` after `GetSendHour`. Matches the real `telegram_offset` pattern (offset lives on the Telegram client, not on `Config`), and keeps the value on the component that actually uses it.
+
+### Cron Schedule
+- Default schedule expression changes from `0 */6 * * *` to `0 * * * *` (every hour).
+
+### New DB Function — User Filtering
+- A new DB function replaces `GetSubscribedUsers` for the broadcast path.
+- Accepts the current UTC time and the configured send hour as parameters (not computed internally — required for testability).
+- Uses PostgreSQL `AT TIME ZONE` and `EXTRACT(HOUR FROM ...)` to convert each user's stored IANA timezone to local time and compare the local hour against the send hour.
+- Users with a null timezone are treated as UTC.
+- Returns only the chat IDs of matching subscribed users.
+
+### Broadcast
+- `broadcast.Run` receives the current UTC time from the scheduler (passed in, not computed internally).
+- Uses the new DB filtering function instead of `GetSubscribedUsers`.
+- All other broadcast logic (quote fetch, send loop, counters) is unchanged.
+
+### Scheduler
+- Captures `time.Now().UTC()` at the moment the cron fires and passes it into `broadcast.Run`.
+
+### `/timezone` Command
+- New command added to the message handler alongside `/start`, `/subscribe`, `/unsubscribe`, `/about`.
+- Responds with an inline keyboard built from a hardcoded slice of supported timezones.
+- Each button displays a human-readable label (e.g. `India (IST)`) and carries the IANA name as its callback data (e.g. `Asia/Kolkata`).
+- The callback handler reads the IANA name from the callback data, updates `users.timezone` for that user, and replies with a confirmation message.
+
+### Supported Timezones
+- ~15–20 entries covering major populated regions worldwide.
+- Hardcoded as a slice of structs (IANA name + display name) in the application code.
+- Future option: migrate to a `supported_timezones` DB table to allow additions without deployment. Not needed at current scale.
+- IANA names sourced from the standard tz database (Wikipedia "List of tz database time zones").
+- **Amended during implementation:** shipped 67 zones grouped into 6 continents (`[]continentGroup{Name, Zones}` in `internal/telegram/timezones.go`), not a flat 15–20 list. A flat keyboard of 67 buttons is unusable; the two-level continent → zone picker handles the expanded list cleanly. See `timezone-command-session.md` for the curated zone breakdown.
+
+### Why IANA names over UTC offsets?
+Many timezones shift their UTC offset seasonally for daylight saving time. Storing a fixed offset (e.g. `-05:00`) would silently break for affected users when clocks change. Storing the IANA name (e.g. `America/New_York`) allows the runtime to compute the correct current offset on every cron fire. India (`Asia/Kolkata`, `+05:30`) does not observe DST — the distinction only matters for affected regions, but using IANA names consistently avoids the problem entirely.
+
+### Why SQL filtering over Go filtering?
+Fetching all subscribed users every hour and discarding non-matching ones in Go would transfer wasted rows on every cron fire. PostgreSQL natively supports timezone-aware hour extraction. Filtering in SQL means only the relevant users are returned, keeping the broadcast path efficient as user count grows.
+
+## Testing Decisions
+
+No tests currently exist in this codebase. The following module is the strongest candidate for introducing the first test:
+
+**New DB filtering function** — this is the deepest module introduced by this feature. It takes a UTC time and a send hour as inputs and returns a list of chat IDs. Given a known set of users with known timezones, the output is fully deterministic. A good test would:
+- Insert users with known timezones into a test DB
+- Call the function with a specific UTC time
+- Assert that only the users whose local hour matches are returned
+- Test the null timezone fallback (UTC) explicitly
+
+A good test checks external behavior only — what goes in, what comes out — not implementation details like query structure or intermediate variables.
+
+## Out of Scope
+
+- Per-user send hour preference — all users share a single globally-configured send hour.
+- Quote cache and deduplication — Phase 2, deferred.
+- Category preference and per-category quote fetching — Phase 3, deferred.
+- `supported_timezones` DB table — future migration, not needed for v1.
+- Retry logic for failed sends — blocked on concurrent broadcast sends, separately deferred.
+- Concurrent broadcast sends — current sequential model is acceptable at current user count.
+
+## Further Notes
+
+- The `bot_config` key-value table already exists and is used for `telegram_offset`. Adding `send_hour` follows the exact same pattern.
+- The `/timezone` command callback flow should follow the existing callback pattern: call `answerCallbackQuery` first, then update the DB, then reply with confirmation.
+- Users who set their timezone will receive their first timezone-adjusted quote on the next cron fire that matches their local send hour — there is no immediate send on setting the timezone.
+
+## Progress
+
+### Done (branch `feat/tz-aware-broadcast`)
+- **DB schema:** `users.timezone TEXT` column added (nullable, no default); `send_hour=9` seeded in `bot_config`.
+- **`db.GetSendHour`:** loads the configured hour at startup. `ErrNoRows` handling now lives on the `row.Scan` error path (previously on the `ParseInt` path where it could never match — fixed).
+- **`db.GetSubscribedUsersForHour(ctx, db, nowUTC, sendHour)`:** filters subscribed users in SQL using `EXTRACT(HOUR FROM $1 AT TIME ZONE COALESCE(timezone, 'UTC')) = $2`. Ready for broadcast to call.
+- **SendHour wiring:** `Broadcast.sendHour` (private field) + `Broadcast.UpdateSendHour(int)` setter. `app.Start` captures the DB value and calls the setter right after `GetSendHour`. See "Config / `sendHour` placement" above for why it's on `Broadcast`, not `Config`.
+- **`/timezone` command:** two-level continent → zone picker covering 67 zones, callback prefix routing (`tz-cont:*`, `tz:*`), allowlist validation before DB write, defensive upsert both at command entry and at zone-select (stale-button case), confirmation reply. See `timezone-command-session.md` for details.
+- **`/about` copy:** updated to list `/timezone` and describe the new once-a-day-at-local-hour behavior.
+
+### Pending
+- First test for `GetSubscribedUsersForHour` (PRD-flagged candidate).
+
+### Done (continued)
+- **GH #10 — broadcast wiring:** `broadcast.Run(ctx, nowUTC time.Time)` now takes the fire-time UTC timestamp and calls `db.GetSubscribedUsersForHour(ctx, b.Database, nowUTC, b.sendHour)` instead of the old unfiltered fetch. Old `GetSubscribedUsers` deleted.
+- **GH #11 — scheduler wiring + cron flip:** `app.Start`'s closure captures `time.Now().UTC()` on every fire (`a.Scheduler.Start(ctx, func() { a.Broadcast.Run(ctx, time.Now().UTC()) })`), keeping `scheduler.Start` generic. Default `--schedule`/`-s` in `config/config.go` flipped from `0 */6 * * *` → `0 * * * *`. Landed together with #10 so the cron cadence change never existed without the filter.
+
+### Known follow-ups in current code
+- **`GetTelegramOffset` has the same dead `ErrNoRows` branch** we just fixed in `GetSendHour` — the `errors.Is(convErr, sql.ErrNoRows)` check lives on the `ParseInt` error path where it can never match. Missing row surfaces as an error caught by the `log.Println` + continue in `app.Start`, so no functional bug; just dead code to clean up.
+
+### Deferred to pre-prod polish
+- Back button on the zone-level keyboard. Needs `editMessageText` / `editMessageReplyMarkup` (swap keyboard in place) rather than new `sendMessage` bubbles. Worth doing before prod; not before feature completion. See `timezone-command-session.md` for the implementation sketch.
+- BotFather registration for `/timezone` after PR merge.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -56,6 +56,7 @@ func (a *App) Start(ctx context.Context) {
 
 	// Update the send_hour retrieved from the DB into the broadcast's client
 	a.Broadcast.UpdateSendHour(int(sendHour))
+	a.Telegram.UpdateSendHour(int(sendHour))
 
 	// Start the telegram long polling
 	go a.Telegram.StartPolling(ctx)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -40,7 +40,7 @@ func New(cfg config.Config) *App {
 func (a *App) Start(ctx context.Context) {
 	// Before starting, fetch the stored telegram offset
 	telegramOffset, getOffsetErr := db.GetTelegramOffset(ctx, a.Database)
-	_, getSendHourErr := db.GetSendHour(ctx, a.Database)
+	sendHour, getSendHourErr := db.GetSendHour(ctx, a.Database)
 
 	if getOffsetErr != nil {
 		log.Println("Error getting `telegram_offset` from `bot_config` table:", getOffsetErr)
@@ -52,6 +52,9 @@ func (a *App) Start(ctx context.Context) {
 
 	// To avoid old messages replays, we store and set the offset if the scheduler restarts for some reason.
 	a.Telegram.UpdateOffset(telegramOffset)
+
+	// Update the send_hour retrieved from the DB into the broadcast's client
+	a.Broadcast.UpdateSendHour(int(sendHour))
 
 	// Start the telegram long polling
 	go a.Telegram.StartPolling(ctx)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -40,9 +40,14 @@ func New(cfg config.Config) *App {
 func (a *App) Start(ctx context.Context) {
 	// Before starting, fetch the stored telegram offset
 	telegramOffset, getOffsetErr := db.GetTelegramOffset(ctx, a.Database)
+	_, getSendHourErr := db.GetSendHour(ctx, a.Database)
 
 	if getOffsetErr != nil {
 		log.Println("Error getting `telegram_offset` from `bot_config` table:", getOffsetErr)
+	}
+
+	if getSendHourErr != nil {
+		log.Fatalln("Error getting `send_hour` from `bot_config` table:", getSendHourErr)
 	}
 
 	// To avoid old messages replays, we store and set the offset if the scheduler restarts for some reason.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"log"
+	"time"
 
 	"github.com/sriram651/go-scheduler/internal/broadcast"
 	"github.com/sriram651/go-scheduler/internal/config"
@@ -60,7 +61,7 @@ func (a *App) Start(ctx context.Context) {
 	go a.Telegram.StartPolling(ctx)
 
 	// Start scheduler service and send in the broadcast run
-	go a.Scheduler.Start(ctx, func() { a.Broadcast.Run(ctx) })
+	go a.Scheduler.Start(ctx, func() { a.Broadcast.Run(ctx, time.Now().UTC()) })
 
 	<-ctx.Done()
 }

--- a/internal/broadcast/broadcast.go
+++ b/internal/broadcast/broadcast.go
@@ -14,6 +14,7 @@ import (
 type Broadcast struct {
 	Quote    *quote.Client
 	Telegram *telegram.Client
+	sendHour int
 	Database *sql.DB
 }
 
@@ -24,6 +25,10 @@ func NewClient(qc *quote.Client, tc *telegram.Client, database *sql.DB) *Broadca
 		Telegram: tc,
 		Database: database,
 	}
+}
+
+func (b *Broadcast) UpdateSendHour(newSendHour int) {
+	b.sendHour = newSendHour
 }
 
 func (b *Broadcast) Run(ctx context.Context) {

--- a/internal/broadcast/broadcast.go
+++ b/internal/broadcast/broadcast.go
@@ -52,7 +52,7 @@ func (b *Broadcast) Run(ctx context.Context, nowUTC time.Time) {
 		broadcastMessage = b.Quote.DefaultQuote
 	}
 
-	subscribedUsers, getSubscribedUsersErr := db.GetUsersForHour(ctx, b.Database, nowUTC, b.sendHour)
+	subscribedUsers, getSubscribedUsersErr := db.GetSubscribedUsersForHour(ctx, b.Database, nowUTC, b.sendHour)
 
 	if getSubscribedUsersErr != nil {
 		log.Println("❌ Cron failed — could not fetch subscribed users:", getSubscribedUsersErr)

--- a/internal/broadcast/broadcast.go
+++ b/internal/broadcast/broadcast.go
@@ -31,7 +31,7 @@ func (b *Broadcast) UpdateSendHour(newSendHour int) {
 	b.sendHour = newSendHour
 }
 
-func (b *Broadcast) Run(ctx context.Context) {
+func (b *Broadcast) Run(ctx context.Context, nowUTC time.Time) {
 	log.Println("🚀 Cron run started")
 
 	var success, failure int
@@ -52,7 +52,7 @@ func (b *Broadcast) Run(ctx context.Context) {
 		broadcastMessage = b.Quote.DefaultQuote
 	}
 
-	subscribedUsers, getSubscribedUsersErr := db.GetSubscribedUsers(b.Database)
+	subscribedUsers, getSubscribedUsersErr := db.GetUsersForHour(ctx, b.Database, nowUTC, b.sendHour)
 
 	if getSubscribedUsersErr != nil {
 		log.Println("❌ Cron failed — could not fetch subscribed users:", getSubscribedUsersErr)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,8 +28,8 @@ func LoadConfig() Config {
 
 	var schedule string
 
-	flag.StringVar(&schedule, "schedule", "0 */6 * * *", "Cron schedule that controls when the reminder is sent (supports standard cron syntax and @every intervals)")
-	flag.StringVar(&schedule, "s", "0 */6 * * *", "Cron schedule that controls when the reminder is sent (supports standard cron syntax and @every intervals)")
+	flag.StringVar(&schedule, "schedule", "0 * * * *", "Cron schedule that controls when the reminder is sent (supports standard cron syntax and @every intervals)")
+	flag.StringVar(&schedule, "s", "0 * * * *", "Cron schedule that controls when the reminder is sent (supports standard cron syntax and @every intervals)")
 
 	flag.Parse()
 

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -37,6 +37,35 @@ func GetTelegramOffset(ctx context.Context, pgDB *sql.DB) (int64, error) {
 	return offset, nil
 }
 
+func GetSendHour(ctx context.Context, pgDB *sql.DB) (int64, error) {
+	query := `
+		SELECT value
+		FROM bot_config
+		WHERE key = $1;
+	`
+
+	row := pgDB.QueryRowContext(ctx, query, "send_hour")
+
+	var rawValue string
+
+	if err := row.Scan(&rawValue); err != nil {
+		return 0, err
+	}
+
+	sendHour, convErr := strconv.ParseInt(rawValue, 10, 64)
+
+	if convErr != nil {
+		if errors.Is(convErr, sql.ErrNoRows) {
+			log.Println("⚠️ [WARNING] bot_config row for send_hour is missing. Insert it with: INSERT INTO bot_config (key, value) VALUES ('send_hour', '9'); — Quotes might be sent at inappropriate hours for some users.")
+			return 0, nil
+		}
+
+		return 0, convErr
+	}
+
+	return sendHour, nil
+}
+
 func UpdateBotConfig(ctx context.Context, pgDB *sql.DB, key string, value int64) error {
 	query := `
 		UPDATE bot_config

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-func GetTelegramOffset(ctx context.Context, pgDB *sql.DB) (int64, error) {
+func GetTelegramOffset(ctx context.Context, pgDB *sql.DB) (int, error) {
 	query := `
 		SELECT value
 		FROM bot_config
@@ -34,7 +34,7 @@ func GetTelegramOffset(ctx context.Context, pgDB *sql.DB) (int64, error) {
 		return 0, convErr
 	}
 
-	return offset, nil
+	return int(offset), nil
 }
 
 func GetSendHour(ctx context.Context, pgDB *sql.DB) (int64, error) {
@@ -48,18 +48,18 @@ func GetSendHour(ctx context.Context, pgDB *sql.DB) (int64, error) {
 
 	var rawValue string
 
-	if err := row.Scan(&rawValue); err != nil {
-		return 0, err
+	if sqlRowErr := row.Scan(&rawValue); sqlRowErr != nil {
+		if errors.Is(sqlRowErr, sql.ErrNoRows) {
+			log.Println("⚠️ [WARNING] bot_config row for send_hour is missing. Insert it with: INSERT INTO bot_config (key, value) VALUES ('send_hour', '9'); — Quotes might be sent at inappropriate hours for some users.")
+			return 0, nil
+		}
+
+		return 0, sqlRowErr
 	}
 
 	sendHour, convErr := strconv.ParseInt(rawValue, 10, 64)
 
 	if convErr != nil {
-		if errors.Is(convErr, sql.ErrNoRows) {
-			log.Println("⚠️ [WARNING] bot_config row for send_hour is missing. Insert it with: INSERT INTO bot_config (key, value) VALUES ('send_hour', '9'); — Quotes might be sent at inappropriate hours for some users.")
-			return 0, nil
-		}
-
 		return 0, convErr
 	}
 

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -66,14 +66,14 @@ func GetSendHour(ctx context.Context, pgDB *sql.DB) (int64, error) {
 	return sendHour, nil
 }
 
-func UpdateBotConfig(ctx context.Context, pgDB *sql.DB, key string, value int64) error {
+func UpdateBotConfig(ctx context.Context, pgDB *sql.DB, key string, value int) error {
 	query := `
 		UPDATE bot_config
 		SET value = $1
 		WHERE key = $2;
 	`
 
-	_, err := pgDB.ExecContext(ctx, query, strconv.Itoa(int(value)), key)
+	_, err := pgDB.ExecContext(ctx, query, strconv.Itoa(value), key)
 
 	if err != nil {
 		return err

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -19,18 +19,18 @@ func GetTelegramOffset(ctx context.Context, pgDB *sql.DB) (int, error) {
 
 	var rawValue string
 
-	if err := row.Scan(&rawValue); err != nil {
-		return 0, err
+	if sqlRowErr := row.Scan(&rawValue); sqlRowErr != nil {
+		if errors.Is(sqlRowErr, sql.ErrNoRows) {
+			log.Println("⚠️ [WARNING] bot_config row for telegram_offset is missing. Insert it with: INSERT INTO bot_config (key, value) VALUES ('telegram_offset', '0'); — offset persistence will not work until this is fixed.")
+			return 0, nil
+		}
+
+		return 0, sqlRowErr
 	}
 
 	offset, convErr := strconv.ParseInt(rawValue, 10, 64)
 
 	if convErr != nil {
-		if errors.Is(convErr, sql.ErrNoRows) {
-			log.Println("⚠️ [WARNING] bot_config row for telegram_offset is missing. Insert it with: INSERT INTO bot_config (key, value) VALUES ('telegram_offset', '0'); — offset persistence will not work until this is fixed.")
-			return 0, nil
-		}
-
 		return 0, convErr
 	}
 

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"log"
+	"time"
 )
 
 type User struct {
@@ -21,6 +22,43 @@ func GetSubscribedUsers(pgDB *sql.DB) ([]int64, error) {
 	`
 
 	rows, err := pgDB.Query(query)
+
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	var chatIDs []int64
+
+	for rows.Next() {
+		var chatId int64
+
+		if err := rows.Scan(&chatId); err != nil {
+			log.Println(err)
+			return nil, err
+		}
+
+		chatIDs = append(chatIDs, chatId)
+	}
+
+	if err := rows.Err(); err != nil {
+		log.Println(err)
+		return nil, err
+	}
+
+	return chatIDs, nil
+}
+
+func GetUsersForHour(ctx context.Context, pgDB *sql.DB, nowUTC time.Time, sendHour int) ([]int64, error) {
+	query := `
+		SELECT chat_id
+		FROM users
+		WHERE subscribed=true AND EXTRACT(HOUR FROM $1 AT TIME ZONE COALESCE(timezone, 'UTC'))=$2;
+	`
+
+	rows, err := pgDB.QueryContext(ctx, query, nowUTC, sendHour)
 
 	if err != nil {
 		log.Println(err)

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -14,44 +14,7 @@ type User struct {
 	Subscribed bool   `json:"subscribed"`
 }
 
-func GetSubscribedUsers(pgDB *sql.DB) ([]int64, error) {
-	query := `
-		SELECT chat_id 
-		FROM users
-		WHERE subscribed = true;
-	`
-
-	rows, err := pgDB.Query(query)
-
-	if err != nil {
-		log.Println(err)
-		return nil, err
-	}
-
-	defer rows.Close()
-
-	var chatIDs []int64
-
-	for rows.Next() {
-		var chatId int64
-
-		if err := rows.Scan(&chatId); err != nil {
-			log.Println(err)
-			return nil, err
-		}
-
-		chatIDs = append(chatIDs, chatId)
-	}
-
-	if err := rows.Err(); err != nil {
-		log.Println(err)
-		return nil, err
-	}
-
-	return chatIDs, nil
-}
-
-func GetUsersForHour(ctx context.Context, pgDB *sql.DB, nowUTC time.Time, sendHour int) ([]int64, error) {
+func GetSubscribedUsersForHour(ctx context.Context, pgDB *sql.DB, nowUTC time.Time, sendHour int) ([]int64, error) {
 	query := `
 		SELECT chat_id
 		FROM users

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -127,3 +127,20 @@ func UpdateSubscription(ctx context.Context, pgDB *sql.DB, chatID int64, subscri
 
 	return nil
 }
+
+func UpdateUserTimezone(ctx context.Context, pgDB *sql.DB, chatID int64, tz string) error {
+	query := `
+		UPDATE users SET timezone = $1 WHERE chat_id = $2
+	`
+
+	_, err := pgDB.ExecContext(ctx, query, tz, chatID)
+
+	if err != nil {
+		log.Println("Error updating user timezone:", err)
+		return err
+	}
+
+	log.Println("User", chatID, "timezone updated to ", tz)
+
+	return nil
+}

--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -10,7 +10,7 @@ type Client struct {
 	baseUrl  string
 	token    string
 	client   *http.Client
-	offset   int64
+	offset   int
 	Database *sql.DB
 }
 
@@ -24,7 +24,7 @@ func NewClient(baseUrl string, token string, httpClientTimeout time.Duration, da
 	}
 }
 
-func (c *Client) UpdateOffset(newOffset int64) {
+func (c *Client) UpdateOffset(newOffset int) {
 	c.offset = newOffset
 }
 

--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -11,6 +11,7 @@ type Client struct {
 	token    string
 	client   *http.Client
 	offset   int
+	sendHour int
 	Database *sql.DB
 }
 
@@ -26,6 +27,10 @@ func NewClient(baseUrl string, token string, httpClientTimeout time.Duration, da
 
 func (c *Client) UpdateOffset(newOffset int) {
 	c.offset = newOffset
+}
+
+func (c *Client) UpdateSendHour(newSendHour int) {
+	c.sendHour = newSendHour
 }
 
 func (c *Client) endpoint(path string, params string) string {

--- a/internal/telegram/handlers.go
+++ b/internal/telegram/handlers.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,15 +37,15 @@ func (c *Client) handleMessage(ctx context.Context, m *Message) {
 }
 
 func (c *Client) handleAbout(ctx context.Context, m *Message) {
-	about := "✨ Daemon Bot ✨\n\n" +
+	about := "✨ *Daemon Bot* ✨\n\n" +
 		"Your daily companion for wisdom and inspiration.\n\n" +
-		"📖 What I do\n" +
-		"Once a day, I deliver a handpicked life quote straight to your chat -- no noise, just words worth reading\n\n" +
-		"⚡ Commands\n" +
-		"/subscribe -- Start receiving quotes\n" +
-		"/unsubscribe -- Pause anytime, no hard feelings\n\n" +
-		"/timezone -- Set your local timezone, no 3 AM pings\n\n" +
-		"/about -- You're here!\n\n" +
+		"📖 *What I do*\n" +
+		"Once a day, I deliver a handpicked life quote straight to your chat — _no noise, just words worth reading_.\n\n" +
+		"⚡ *Commands*\n" +
+		"/subscribe — Start receiving quotes\n" +
+		"/unsubscribe — Pause anytime, no hard feelings\n" +
+		"/timezone — Set your local timezone, _no 3 AM pings_\n" +
+		"/about — You're here!\n\n" +
 		"Built with ☕ and Go."
 
 	sendCtx, sendCancel := context.WithTimeout(ctx, 5*time.Second)
@@ -69,7 +70,7 @@ func (c *Client) handleStart(ctx context.Context, m *Message) {
 		log.Println("Error adding new user:", addNewUserErr)
 	}
 
-	welcomeMessage := "Hey " + m.Chat.FirstName + "!\n\nI am Daemon Bot. I send life quotes every 6 hours. If you would love that, feel free to subscribe to me to get started."
+	welcomeMessage := "Hey there!\n\nI am *Daemon Bot*. I send a handpicked life quote once a day. If you'd love that, tap *Subscribe* below — then run /timezone so I can hit the right hour for you."
 
 	// The Inline keyboard buttons to subscribe and unsubscribe
 	welcomeReplyMarkup := &ReplyMarkup{
@@ -175,7 +176,7 @@ func (c *Client) handleTimezone(ctx context.Context, m *Message) error {
 		return addNewUserErr
 	}
 
-	timezoneHandlerMessage := "🌍 Let's set your timezone" + "\nThis way I can send quotes at a reasonable hour wherever you are - no 3 AM pings." + "\n\nPick your region to get started:"
+	timezoneHandlerMessage := "🌍 *Let's set your timezone*\n\nSo I can send quotes at a sensible hour wherever you are — _no 3 AM pings_.\n\nPick your region to get started:"
 
 	timezonesReplyMarkup := &ReplyMarkup{
 		InlineKeyboard: [][]InlineKeyboardButton{
@@ -200,7 +201,8 @@ func (c *Client) handleTimezone(ctx context.Context, m *Message) error {
 }
 
 func (c *Client) handleTimezoneContinent(ctx context.Context, cbData string, m *Message) error {
-	timezoneContinentHandlerMessage := "Pick your timezone in " + strings.ToTitle(cbData) + ", or tap ← Back to change region."
+	continentTitle := strings.ToUpper(cbData[:1]) + cbData[1:]
+	timezoneContinentHandlerMessage := "Pick your timezone in *" + continentTitle + "*:"
 
 	var zones []string
 
@@ -298,7 +300,19 @@ func (c *Client) handleTimezoneSelect(ctx context.Context, cbData string, m *Mes
 }
 
 func (c *Client) replyUpdateTimezone(ctx context.Context, tz string, chatId int64) {
-	answerCallbackText := "✅ Timezone saved: " + tz + "\n\nNo more 3 AM pings - quotes will land at a reasonable local hour from now on. Run /timezone again anytime to change it."
+	loc, _ := time.LoadLocation(tz)
+	_, offset := time.Now().In(loc).Zone()
+
+	sendHourOffsetInMinutes := (offset / 60) % 60
+	offsetMinutesStr := strconv.Itoa(sendHourOffsetInMinutes)
+
+	if sendHourOffsetInMinutes < 10 {
+		offsetMinutesStr = "0" + offsetMinutesStr
+	}
+
+	userSendTime := strconv.Itoa(c.sendHour) + ":" + offsetMinutesStr
+
+	answerCallbackText := "✅ *Timezone saved:* `" + tz + "`\n\nNo more 3 AM pings — quotes will land at `" + userSendTime + "hrs` from now on. Run /timezone again to change it."
 
 	sendCtx, sendCancel := context.WithTimeout(ctx, 5*time.Second)
 
@@ -312,7 +326,7 @@ func (c *Client) replyUpdateTimezone(ctx context.Context, tz string, chatId int6
 }
 
 func (c *Client) replyTimezoneUpdateErr(ctx context.Context, chatId int64) {
-	answerCallbackText := "Couldn't save your timezone just now. Please try again in a moment."
+	answerCallbackText := "Couldn't save your timezone just now. Please try /timezone again in a moment."
 
 	sendCtx, sendCancel := context.WithTimeout(ctx, 5*time.Second)
 
@@ -376,9 +390,9 @@ func (c *Client) replySubscription(ctx context.Context, subscribed bool, chatId 
 	var answerCallbackText string
 
 	if subscribed {
-		answerCallbackText = "Thank you for subscribing! You will start receiving quotes every 6 hours. \n\nI hope you enjoy the journey."
+		answerCallbackText = "You're subscribed ✨\n\nYou'll get a life quote once a day. If you haven't already, run /timezone so I send it at a sensible local hour — _no 3 AM pings_."
 	} else {
-		answerCallbackText = "No problem, you can come back to subscribe whenever. \n\nI hope you have a good day!"
+		answerCallbackText = "Unsubscribed. No hard feelings — /subscribe again anytime."
 	}
 
 	sendCtx, sendCancel := context.WithTimeout(ctx, 5*time.Second)
@@ -396,9 +410,9 @@ func (c *Client) replySubscriptionChangeErr(ctx context.Context, subscribed bool
 	var answerCallbackText string
 
 	if subscribed {
-		answerCallbackText = "We were unable to subscribe you at the moment. Please try again later."
+		answerCallbackText = "Couldn't subscribe you right now. Please try again in a moment."
 	} else {
-		answerCallbackText = "We were unable to unsubscribe you at the moment. Please try again later."
+		answerCallbackText = "Couldn't unsubscribe you right now. Please try again in a moment."
 	}
 
 	sendCtx, sendCancel := context.WithTimeout(ctx, 5*time.Second)
@@ -417,6 +431,7 @@ func (c *Client) HandleSend(ctx context.Context, chatId int64, text string, repl
 		ChatID:      chatId,
 		Text:        text,
 		ReplyMarkup: replyMarkup,
+		ParseMode:   "Markdown",
 	}
 
 	messageJson, marshalErr := json.Marshal(message)

--- a/internal/telegram/handlers.go
+++ b/internal/telegram/handlers.go
@@ -28,6 +28,10 @@ func (c *Client) handleMessage(ctx context.Context, m *Message) {
 		}
 	case "/about":
 		c.handleAbout(ctx, m)
+	case "/timezone":
+		if err := c.handleTimezone(ctx, m); err != nil {
+			log.Println("error handling timezone:", err)
+		}
 	}
 }
 
@@ -124,6 +128,25 @@ func (c *Client) handleCallback(ctx context.Context, cb *CallbackQuery) {
 		return
 	}
 
+	isTimezoneContPresent := strings.HasPrefix(cb.Data, "tz-cont:")
+	isTimezonePresent := strings.HasPrefix(cb.Data, "tz:")
+
+	if isTimezoneContPresent {
+		continent, _ := strings.CutPrefix(cb.Data, "tz-cont:")
+		if err := c.handleTimezoneContinent(ctx, continent, cb.Message); err != nil {
+			return
+		}
+
+		return
+	} else if isTimezonePresent {
+		timezone, _ := strings.CutPrefix(cb.Data, "tz:")
+		if err := c.handleTimezoneSelect(ctx, timezone, cb.Message); err != nil {
+			return
+		}
+
+		return
+	}
+
 	switch cb.Data {
 	case "subscribe":
 		if err := c.handleSubscribe(ctx, cb.Message, true); err != nil {
@@ -134,6 +157,158 @@ func (c *Client) handleCallback(ctx context.Context, cb *CallbackQuery) {
 		if err := c.handleSubscribe(ctx, cb.Message, false); err != nil {
 			return
 		}
+	}
+}
+
+func (c *Client) handleTimezone(ctx context.Context, m *Message) error {
+	addNewUserErr := db.AddNewUser(ctx, c.Database, db.User{
+		ChatId:    m.Chat.ID,
+		FirstName: m.Chat.FirstName,
+		UserName:  m.Chat.UserName,
+	})
+
+	if addNewUserErr != nil {
+		log.Println("Error adding new user:", addNewUserErr)
+
+		c.replyTimezoneUpdateErr(ctx, m.Chat.ID)
+		return addNewUserErr
+	}
+
+	timezoneHandlerMessage := "🌍 Let's set your timezone" + "\nThis way I can send quotes at a reasonable hour wherever you are - no 3 AM pings." + "\n\nPick your region to get started:"
+
+	timezonesReplyMarkup := &ReplyMarkup{
+		InlineKeyboard: [][]InlineKeyboardButton{
+			{{Text: "Asia", CallbackData: "tz-cont:asia"}, {Text: "Europe", CallbackData: "tz-cont:europe"}},
+			{{Text: "Americas", CallbackData: "tz-cont:americas"}, {Text: "Africa", CallbackData: "tz-cont:africa"}},
+			{{Text: "Oceania", CallbackData: "tz-cont:oceania"}, {Text: "Other", CallbackData: "tz-cont:other"}},
+		},
+	}
+
+	sendCtx, sendCancel := context.WithTimeout(ctx, 5*time.Second)
+
+	sendErr := c.HandleSend(sendCtx, m.Chat.ID, timezoneHandlerMessage, timezonesReplyMarkup)
+
+	sendCancel()
+
+	if sendErr != nil {
+		log.Println(sendErr)
+		return sendErr
+	}
+
+	return nil
+}
+
+func (c *Client) handleTimezoneContinent(ctx context.Context, cbData string, m *Message) error {
+	timezoneContinentHandlerMessage := "Pick your timezone in " + cbData + ", or tap ← Back to change region."
+
+	var zones []string
+
+	for _, continentGroup := range timezonesByContinent {
+		continentName := strings.ToLower(continentGroup.Name)
+
+		if continentName == cbData {
+			zones = continentGroup.Zones
+			break
+		}
+	}
+
+	if len(zones) == 0 {
+		return fmt.Errorf("Invalid continent selection received - %s", cbData)
+	}
+
+	var keyboardMarkup [][]InlineKeyboardButton
+
+	// Used as buffer
+	var keyboardRow []InlineKeyboardButton
+
+	for _, zone := range zones {
+		if len(keyboardRow) == 2 {
+			keyboardMarkup = append(keyboardMarkup, keyboardRow)
+
+			// Empty out the buffer
+			keyboardRow = []InlineKeyboardButton{}
+		}
+
+		zoneButton := InlineKeyboardButton{
+			Text:         zone,
+			CallbackData: "tz:" + zone,
+		}
+
+		keyboardRow = append(keyboardRow, zoneButton)
+	}
+
+	if len(keyboardRow) != 0 {
+		keyboardMarkup = append(keyboardMarkup, keyboardRow)
+
+		// Empty out the buffer
+		keyboardRow = []InlineKeyboardButton{}
+	}
+
+	timezonesReplyMarkup := &ReplyMarkup{
+		InlineKeyboard: keyboardMarkup,
+	}
+
+	sendCtx, sendCancel := context.WithTimeout(ctx, 5*time.Second)
+
+	sendErr := c.HandleSend(sendCtx, m.Chat.ID, timezoneContinentHandlerMessage, timezonesReplyMarkup)
+
+	sendCancel()
+
+	if sendErr != nil {
+		log.Println(sendErr)
+		return sendErr
+	}
+
+	return nil
+}
+
+func (c *Client) handleTimezoneSelect(ctx context.Context, cbData string, m *Message) error {
+	fmt.Println("User has selected their timezone: ", cbData)
+	isTimezoneValid := IsValidTimeZone(cbData)
+
+	if !isTimezoneValid {
+		return fmt.Errorf("Selected timezone is not valid: %s", cbData)
+	}
+
+	tzUpdateErr := db.UpdateUserTimezone(ctx, c.Database, m.Chat.ID, cbData)
+
+	if tzUpdateErr != nil {
+		log.Println("Error updating user's timezone. chat_id: ", m.Chat.ID, ", timezone: ", cbData)
+		c.replyTimezoneUpdateErr(ctx, m.Chat.ID)
+
+		return tzUpdateErr
+	}
+
+	c.replyUpdateTimezone(ctx, cbData, m.Chat.ID)
+
+	return nil
+}
+
+func (c *Client) replyUpdateTimezone(ctx context.Context, tz string, chatId int64) {
+	answerCallbackText := "✅ Timezone saved: " + tz + "\n\nNo more 3 AM pings - quotes will land at a reasonable local hour from now on. Run /timezone again anytime to change it."
+
+	sendCtx, sendCancel := context.WithTimeout(ctx, 5*time.Second)
+
+	sendErr := c.HandleSend(sendCtx, chatId, answerCallbackText, nil)
+
+	sendCancel()
+
+	if sendErr != nil {
+		log.Println(sendErr)
+	}
+}
+
+func (c *Client) replyTimezoneUpdateErr(ctx context.Context, chatId int64) {
+	answerCallbackText := "Couldn't save your timezone just now. Please try again in a moment."
+
+	sendCtx, sendCancel := context.WithTimeout(ctx, 5*time.Second)
+
+	sendErr := c.HandleSend(sendCtx, chatId, answerCallbackText, nil)
+
+	sendCancel()
+
+	if sendErr != nil {
+		log.Println(sendErr)
 	}
 }
 

--- a/internal/telegram/handlers.go
+++ b/internal/telegram/handlers.go
@@ -303,9 +303,15 @@ func (c *Client) replyUpdateTimezone(ctx context.Context, tz string, chatId int6
 	loc, _ := time.LoadLocation(tz)
 	_, offset := time.Now().In(loc).Zone()
 
-	sendHourOffsetInMinutes := (offset / 60) % 60
-	offsetMinutesStr := strconv.Itoa(sendHourOffsetInMinutes)
+	sendHourOffsetInMinutes := ((offset / 60) % 60)
 
+	if sendHourOffsetInMinutes < 0 {
+		sendHourOffsetInMinutes = -sendHourOffsetInMinutes
+	}
+
+	offsetMinutesStr := strconv.Itoa(int(sendHourOffsetInMinutes))
+
+	// Padding a zero (0) at the start so we don't get outputs like "9:0hrs" instead we get "9:00hrs"
 	if sendHourOffsetInMinutes < 10 {
 		offsetMinutesStr = "0" + offsetMinutesStr
 	}

--- a/internal/telegram/handlers.go
+++ b/internal/telegram/handlers.go
@@ -39,11 +39,12 @@ func (c *Client) handleAbout(ctx context.Context, m *Message) {
 	about := "✨ Daemon Bot ✨\n\n" +
 		"Your daily companion for wisdom and inspiration.\n\n" +
 		"📖 What I do\n" +
-		"Every 6 hours, I deliver a handpicked life quote straight to your chat — no noise, just words worth reading.\n\n" +
+		"Once a day, I deliver a handpicked life quote straight to your chat -- no noise, just words worth reading\n\n" +
 		"⚡ Commands\n" +
-		"/subscribe — Start receiving quotes\n" +
-		"/unsubscribe — Pause anytime, no hard feelings\n" +
-		"/about — You're here!\n\n" +
+		"/subscribe -- Start receiving quotes\n" +
+		"/unsubscribe -- Pause anytime, no hard feelings\n\n" +
+		"/timezone -- Set your local timezone, no 3 AM pings\n\n" +
+		"/about -- You're here!\n\n" +
 		"Built with ☕ and Go."
 
 	sendCtx, sendCancel := context.WithTimeout(ctx, 5*time.Second)
@@ -199,7 +200,7 @@ func (c *Client) handleTimezone(ctx context.Context, m *Message) error {
 }
 
 func (c *Client) handleTimezoneContinent(ctx context.Context, cbData string, m *Message) error {
-	timezoneContinentHandlerMessage := "Pick your timezone in " + cbData + ", or tap ← Back to change region."
+	timezoneContinentHandlerMessage := "Pick your timezone in " + strings.ToTitle(cbData) + ", or tap ← Back to change region."
 
 	var zones []string
 
@@ -263,11 +264,23 @@ func (c *Client) handleTimezoneContinent(ctx context.Context, cbData string, m *
 }
 
 func (c *Client) handleTimezoneSelect(ctx context.Context, cbData string, m *Message) error {
-	fmt.Println("User has selected their timezone: ", cbData)
 	isTimezoneValid := IsValidTimeZone(cbData)
 
 	if !isTimezoneValid {
 		return fmt.Errorf("Selected timezone is not valid: %s", cbData)
+	}
+
+	addNewUserErr := db.AddNewUser(ctx, c.Database, db.User{
+		ChatId:    m.Chat.ID,
+		FirstName: m.Chat.FirstName,
+		UserName:  m.Chat.UserName,
+	})
+
+	if addNewUserErr != nil {
+		log.Println("Error adding new user:", addNewUserErr)
+
+		c.replyTimezoneUpdateErr(ctx, m.Chat.ID)
+		return addNewUserErr
 	}
 
 	tzUpdateErr := db.UpdateUserTimezone(ctx, c.Database, m.Chat.ID, cbData)

--- a/internal/telegram/polling.go
+++ b/internal/telegram/polling.go
@@ -24,7 +24,7 @@ func (c *Client) StartPolling(ctx context.Context) {
 
 			for _, u := range updates {
 				c.routeUpdate(ctx, u)
-				newOffset := int64(u.UpdateID + 1)
+				newOffset := u.UpdateID + 1
 				c.UpdateOffset(newOffset)
 
 				if err := db.UpdateBotConfig(ctx, c.Database, "telegram_offset", newOffset); err != nil {

--- a/internal/telegram/timezones.go
+++ b/internal/telegram/timezones.go
@@ -1,0 +1,34 @@
+package telegram
+
+import "strings"
+
+type continentGroup struct {
+	Name  string
+	Zones []string
+}
+
+var timezonesByContinent = []continentGroup{
+	{Name: "Asia", Zones: []string{"Asia/Kolkata", "Asia/Dubai", "Asia/Karachi", "Asia/Dhaka", "Asia/Bangkok", "Asia/Jakarta", "Asia/Singapore", "Asia/Shanghai", "Asia/Hong_Kong", "Asia/Manila", "Asia/Tokyo",
+		"Asia/Seoul", "Asia/Tehran", "Asia/Jerusalem", "Asia/Riyadh", "Indian/Maldives"}},
+	{Name: "Africa", Zones: []string{"Africa/Cairo", "Africa/Lagos", "Africa/Johannesburg", "Africa/Nairobi", "Africa/Casablanca", "Africa/Accra", "Africa/Addis_Ababa", "Africa/Algiers", "Africa/Tunis",
+		"Africa/Kinshasa", "Indian/Mauritius", "Indian/Reunion"}},
+	{Name: "Americas", Zones: []string{"America/New_York", "America/Chicago", "America/Denver", "America/Los_Angeles", "America/Toronto", "America/Vancouver", "America/Anchorage", "America/Mexico_City",
+		"America/Sao_Paulo", "America/Buenos_Aires", "America/Santiago", "America/Lima", "America/Bogota", "America/Caracas"}},
+	{Name: "Europe", Zones: []string{"Europe/London", "Europe/Dublin", "Europe/Lisbon", "Europe/Paris", "Europe/Berlin", "Europe/Madrid", "Europe/Rome", "Europe/Amsterdam", "Europe/Warsaw", "Europe/Athens",
+		"Europe/Istanbul", "Europe/Moscow"}},
+	{Name: "Oceania", Zones: []string{"Australia/Sydney", "Australia/Melbourne", "Australia/Brisbane", "Australia/Perth", "Australia/Adelaide", "Australia/Darwin", "Pacific/Auckland", "Pacific/Fiji", "Pacific/Honolulu",
+		"Pacific/Guam"}},
+	{Name: "Other", Zones: []string{"UTC", "Atlantic/Reykjavik", "Atlantic/Azores"}},
+}
+
+func IsValidTimeZone(inputZone string) bool {
+	for _, continent := range timezonesByContinent {
+		for _, zone := range continent.Zones {
+			if strings.EqualFold(inputZone, zone) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/internal/telegram/types.go
+++ b/internal/telegram/types.go
@@ -31,6 +31,7 @@ type SendMessage struct {
 	ChatID      int64        `json:"chat_id"`
 	Text        string       `json:"text"`
 	ReplyMarkup *ReplyMarkup `json:"reply_markup,omitempty"`
+	ParseMode   string       `json:"parse_mode,omitempty"`
 }
 
 type ReplyMarkup struct {


### PR DESCRIPTION
## Summary
- Adds per-user timezone + global `send_hour` so quotes deliver at the user's local hour. Cron flipped to `0 * * * *`; SQL filters subscribed users whose local hour (per stored IANA tz, UTC fallback) matches `send_hour`.
- Ships `/timezone` command with a two-level continent→zone picker (67 IANA zones), allowlist validation, and a confirmation reply that tells the user the exact local HH:MM they'll receive quotes at (correct for `:00`, `:30`, `:45` offset zones).
- Switches Telegram replies to legacy Markdown and refreshes copy across `/start`, `/about`, `/subscribe`, `/unsubscribe`, `/timezone`. Introduces `GetSendHour` + `GetSubscribedUsersForHour`, deletes the now-unused `GetSubscribedUsers`, and wires `send_hour` onto both `Broadcast` and `Telegram` clients via setters populated in `app.Start`.

Closes #6
Closes #7
Closes #8
Closes #9
Closes #10
Closes #11